### PR TITLE
fix main content centering

### DIFF
--- a/sass/text.scss
+++ b/sass/text.scss
@@ -56,3 +56,7 @@ main > .text {
 .content a {
     color: var(--primary-color),
 }
+
+.hero {
+    justify-content: center;
+}


### PR DESCRIPTION
This fixes content being cut off on mobile devices in portrait mode.
before:
![image](https://github.com/user-attachments/assets/864e060f-0fc8-4636-bde1-82296327ec0d)

after:
![image](https://github.com/user-attachments/assets/ec78da74-5d74-40b6-8569-78033e152e4a)
